### PR TITLE
Get rid of C++11 requirement and address Rf_warning issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hipread
 Type: Package
 Title: Read Hierarchical Fixed Width Files
-Version: 0.2.3.9000
+Version: 0.2.4
 Authors@R: c(
     person("Greg", "Freedman Ellis", role = "aut"),
     person("Derek Burk", email = "ipums+cran@umn.edu", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,5 @@ Suggests:
     dplyr,
     readr,
     testthat
-SystemRequirements:
-    C++11
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-# hipread (development version)
+# hipread 0.2.4
+* Fixes for one warning and one note from CRAN checks
 
 # hipread 0.2.3
 * hipread now uses roxygen2 version 7.2.1.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,14 @@
 ## Reasons for release
 
-* Rebuild roxygen2 documentation to conform with new HTML5 guidelines
-* Remove LazyData field from DESCRIPTION file
-* Fix bad URL in README.md
+Fixes to resolve one warning and one note from https://cran.r-project.org/web/checks/check_results_hipread.html
+
+* Warning: Pass a string literal for the format argument of Rf_warning(), to 
+  avoid -Wformat-security warning.
+* Remove `SystemRequirements: C++11` from Description file to avoid note about 
+  old C++ version.
 
 ## Test environments
-* local Windows, R 4.2.1
+* local Windows, R 4.3.2
 * win builder release and devel
 * MacOS (release), Windows (release), and Ubuntu (devel, release, old release) 
   via GitHub Actions

--- a/src/column.cpp
+++ b/src/column.cpp
@@ -171,7 +171,7 @@ RObject columnsToDf(std::vector<ColumnPtr> columns, Rcpp::CharacterVector names,
     if (columns[i]->has_failures()) {
       std::string message = columns[i]->describe_failures(
               Rcpp::as<std::string>(names[static_cast<long>(i)]));
-      Rf_warning(message.c_str());
+      Rf_warning("%s", message.c_str());
     }
     out[static_cast<long>(i)] = columns[i]->vector();
   }

--- a/tests/testthat/test-coltype-warning.R
+++ b/tests/testthat/test-coltype-warning.R
@@ -1,0 +1,26 @@
+test_that("bad column types generates warning", {
+  expect_warning(
+    hipread_long(
+      hipread_example("test-basic.dat"),
+      list(
+        H = hip_fwf_widths(
+          c(1, 3, 3, 3, 2),
+          c("rt", "hhnum", "hh_char", "hh_dbl", "hh_impdbl"),
+          # Misspecify hh_char as a double type
+          c("character", "character", "double", "double", "double"),
+          trim_ws = c(TRUE, FALSE, TRUE, NA, NA),
+          imp_dec = c(NA, NA, NA, 0, 1)
+        ),
+        P = hip_fwf_widths(
+          c(1, 3, 1, 3, 1),
+          c("rt", "hhnum", "pernum", "per_dbl", "per_mix"),
+          c("character", "character", "integer", "double", "character"),
+          trim_ws = c(TRUE, FALSE, NA, NA, TRUE),
+          imp_dec = c(NA, NA, NA, 0, NA)
+        )
+      ),
+      hip_rt(1, 1)
+    ),
+    regexp = "could not convert"
+  )
+})


### PR DESCRIPTION
As of R 4.3, C++17 became the default version, and CRAN checks now flag any required versions older than that (see [this tidyverse blog post](https://www.tidyverse.org/blog/2023/03/cran-checks-compiled-code/)).

We also got a CRAN check warning about our usage of `Rf_warning()`:

```
column.cpp:174:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
```

Still figuring out the fix for that one, but want to see if I can replicate the warning when I trigger GH Actions. [This Rcpp fix](https://github.com/RcppCore/Rcpp/commit/699fc0aa5f8c9b4a8f9efc4c46098079f10a8ddd) is a promising lead though.