### PR TITLE
Fix for segfaults with `read_list()`

### DIFF
--- a/src/read_full.cpp
+++ b/src/read_full.cpp
@@ -172,7 +172,7 @@ RObject read_list(
 
     if (cur_pos_rt[rt_index] >= out[rt_index][0]->size()) {
       // Resize by guessing from the progress bar
-      resizeAllColumns(out[rt_index], static_cast<int>((cur_pos_rt[rt_found] / data->progress_info().first) * 1.1));
+      resizeAllColumns(out[rt_index], static_cast<int>((cur_pos_rt[rt_index] / data->progress_info().first) * 1.1));
     }
 
     // Check if raw line is long enough

--- a/tests/testthat/test-list-full.R
+++ b/tests/testthat/test-list-full.R
@@ -55,3 +55,23 @@ test_that("basic example matches long format", {
   )
 })
 
+test_that("Can read rectangular into a list", {
+  actual <- hipread_list(
+    hipread_example("test-basic.dat"),
+    hip_fwf_widths(
+      c(1, 2, 1),
+      c("var1", "var2", "var3"),
+      c("character", "character", "character")
+    ),
+    hip_rt(1, 0)
+  )
+
+  expect_true(is.list(actual))
+  expect_equal(length(actual), 1)
+  expect_equal(nrow(actual[[1]]), 0)
+  expect_equal(ncol(actual[[1]]), 3)
+  expect_equal(
+    actual[[1]]$var1,
+    c("H", "P", "P", "P", "H", "P", "P", "H", "P")
+  )
+})


### PR DESCRIPTION
Small typo meant that resizing wasn't always using a valid number. Seems to fix both #2 and #3