### PR TITLE
Don't use non-API functions SETLENGTH and SET_TRUELENGTH

### DIFF
--- a/src/column.cpp
+++ b/src/column.cpp
@@ -4,6 +4,7 @@
 #include "column.h"
 #include "string_utils.h"
 #include "iconv.h"
+#include "column_utils.h"
 
 #include <Rcpp.h>
 using namespace Rcpp;
@@ -101,46 +102,27 @@ void ColumnInteger::setValue(int i, const char* x_start, const char* x_end) {
 }
 
 void ColumnCharacter::resize(int n) {
-  if (n == n_)
-    return;
-
-  if (n > 0 && n < n_) {
-    SETLENGTH(values_, n);
-    SET_TRUELENGTH(values_, n);
-  } else {
-    values_ = Rf_lengthgets(values_, n);
-  }
+  if (n == n_) return;
+  values_ = resize_character_vector(values_, n_, n);
   n_ = n;
-
 }
 
-void ColumnDouble::resize(int n) {
-  if (n == n_)
-    return;
 
-  if (n > 0 && n < n_) {
-    SETLENGTH(values_, n);
-    SET_TRUELENGTH(values_, n);
-  } else {
-    values_ = Rf_lengthgets(values_, n);
-  }
+void ColumnDouble::resize(int n) {
+  if (n == n_) return;
+  values_ = resize_numeric_vector(values_, n_, n);
   n_ = n;
   valuepointer = REAL(values_);
 }
 
-void ColumnInteger::resize(int n) {
-  if (n == n_)
-    return;
 
-  if (n > 0 && n < n_) {
-    SETLENGTH(values_, n);
-    SET_TRUELENGTH(values_, n);
-  } else {
-    values_ = Rf_lengthgets(values_, n);
-  }
+void ColumnInteger::resize(int n) {
+  if (n == n_) return;
+  values_ = resize_integer_vector(values_, n_, n);
   n_ = n;
   valuepointer = INTEGER(values_);
 }
+
 
 std::vector<ColumnPtr> createAllColumns(CharacterVector types, Rcpp::List var_opts, Iconv* pEncoder_) {
   int num_cols = static_cast<int>(types.size());

--- a/src/column_utils.h
+++ b/src/column_utils.h
@@ -1,0 +1,56 @@
+#ifndef VECTOR_UTILS_H
+#define VECTOR_UTILS_H
+
+#include <Rinternals.h>
+#include <algorithm>
+#include <cstring>  // for memcpy
+
+inline SEXP resize_numeric_vector(SEXP original, int old_size, int new_size) {
+  SEXP new_vec = PROTECT(Rf_allocVector(REALSXP, new_size));
+  double* new_data = REAL(new_vec);
+
+  std::fill_n(new_data, new_size, NA_REAL);
+
+  if (original != R_NilValue && old_size > 0) {
+    int copy_len = std::min(old_size, new_size);
+    memcpy(new_data, REAL(original), copy_len * sizeof(double));
+  }
+
+  UNPROTECT(1);
+  return new_vec;
+}
+
+inline SEXP resize_integer_vector(SEXP original, int old_size, int new_size) {
+  SEXP new_vec = PROTECT(Rf_allocVector(INTSXP, new_size));
+  int* new_data = INTEGER(new_vec);
+
+  std::fill_n(new_data, new_size, NA_INTEGER);
+
+  if (original != R_NilValue && old_size > 0) {
+    int copy_len = std::min(old_size, new_size);
+    memcpy(new_data, INTEGER(original), copy_len * sizeof(int));
+  }
+
+  UNPROTECT(1);
+  return new_vec;
+}
+
+inline SEXP resize_character_vector(SEXP original, int old_size, int new_size) {
+  SEXP new_vec = PROTECT(Rf_allocVector(STRSXP, new_size));
+
+  for (int i = 0; i < new_size; ++i) {
+    SET_STRING_ELT(new_vec, i, NA_STRING);
+  }
+
+  if (original != R_NilValue && old_size > 0) {
+    int copy_len = std::min(old_size, new_size);
+    for (int i = 0; i < copy_len; ++i) {
+      SET_STRING_ELT(new_vec, i, STRING_ELT(original, i));
+    }
+  }
+
+  UNPROTECT(1);
+  return new_vec;
+}
+
+#endif // VECTOR_UTILS_H


### PR DESCRIPTION
From CRAN checks:

```
Version: 0.2.4
Check: compiled code
Result: NOTE
  File ‘hipread/libs/hipread.so’:
    Found non-API calls to R: ‘SETLENGTH’, ‘SET_TRUELENGTH’
  
  Compiled code should not call non-API entry points in R.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual,
  and section ‘Moving into C API compliance’ for issues with the use of
  non-API entry points.
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/hipread-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/hipread-00check.html), [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/hipread-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/hipread-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/hipread-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/hipread-00check.html), [r-release-macos-arm64](https://www.r-project.org/nosvn/R.check/r-release-macos-arm64/hipread-00check.html), [r-release-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-release-macos-x86_64/hipread-00check.html)

Version: 0.2.4
Check: compiled code
Result: NOTE
  File 'hipread/libs/x64/hipread.dll':
    Found non-API calls to R: 'SETLENGTH', 'SET_TRUELENGTH'
  
  Compiled code should not call non-API entry points in R.
  
  See 'Writing portable packages' in the 'Writing R Extensions' manual,
  and section 'Moving into C API compliance' for issues with the use of
  non-API entry points.
Flavors: [r-devel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/hipread-00check.html), [r-release-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-release-windows-x86_64/hipread-00check.html)
```

The solution I've implemented here involves a fair bit of copying, unfortunately. However, in my testing, it doesn't cause a drastic slowdown in file read time -- as one example, a file with 19 million records and 31 variables that previously took 1.5 minutes to read will now take 2 minutes.